### PR TITLE
Remove beman-cmake-tools from baseline.json

### DIFF
--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1,9 +1,5 @@
 {
   "default": {
-    "beman-cmake-tools": {
-      "baseline": "2025-05-09",
-      "port-version": 0
-    },
     "beman-exemplar": {
       "baseline": "2.3.0",
       "port-version": 0


### PR DESCRIPTION
These are no longer needed since we rely on the upstream vcpkg-cmake-tools instead.