### PR TITLE
Remove beman-cmake-tools from versions/

### DIFF
--- a/versions/b-/beman-cmake-tools.json
+++ b/versions/b-/beman-cmake-tools.json
@@ -1,9 +1,0 @@
-{
-  "versions": [
-    {
-      "git-tree": "0ac1dde44bc34365fd51479b535a6bd27aaa92ee",
-      "version-date": "2025-05-09",
-      "port-version": 0
-    }
-  ]
-}


### PR DESCRIPTION
These are no longer needed since we rely on the upstream vcpkg-cmake-tools instead.